### PR TITLE
Limit input to 16 characters

### DIFF
--- a/DMI/window/input_data.cpp
+++ b/DMI/window/input_data.cpp
@@ -69,6 +69,7 @@ data_set([this](std::string s){setData(s);}), more("symbols/Navigation/NA_23.bmp
 }
 void input_data::setData(std::string s)
 {
+    if (s.length() > 16) return;
     if (window != nullptr) window->inputChanged(this);
     techcross_invalid = techrange_invalid = techresol_invalid = operatcross_invalid = operatrange_invalid = false;
     data = s;


### PR DESCRIPTION
Fixes #54

Limit input to 16 characters which seems to be the limit IRL.
I don't know if my implementation is the cleanest but this limit seems to make all the characters stay in their boxes in all menus I tested. It is a magic number without comment, it could be set as a macro or as a variable.


<img width="4000" height="3000" alt="image" src="https://github.com/user-attachments/assets/105ed245-354f-4052-b00e-261e8edee4b3" />
